### PR TITLE
ci: remove redundant gradle test task

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,9 +35,6 @@ jobs:
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build
-
-    - name: Run tests with Gradle Wrapper
-      run: ./gradlew test
       
   dependency-submission:
 


### PR DESCRIPTION
By default Gradle build already includes the test task, so it's redundant and can be removed.