### PR TITLE
fix: webhook and update max connection size

### DIFF
--- a/src/main/kotlin/dev/lewischan/weatherbot/bot/TelegramBot.kt
+++ b/src/main/kotlin/dev/lewischan/weatherbot/bot/TelegramBot.kt
@@ -38,11 +38,9 @@ class TelegramBot(
 
     @PreDestroy
     fun stop() {
-        if (telegramBotProperties.useWebhook) {
-            logger.info("Stopping webhook")
-            telegramBot.stopWebhook()
-        } else {
-            logger.info("Stopping polling")
+        logger.info("Stopping bot")
+
+        if (!telegramBotProperties.useWebhook) {
             telegramBot.stopPolling()
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ server.shutdown=graceful
 
 spring.application.name=weather-bot
 spring.datasource.hikari.minimum-idle=3
-spring.datasource.hikari.maximum-pool-size=9
+spring.datasource.hikari.maximum-pool-size=5
 spring.datasource.url=jdbc:postgresql://${ENV_DB_HOST}:${ENV_DB_PORT}/${ENV_DB_NAME}
 spring.datasource.username=${ENV_DB_USERNAME}
 spring.datasource.password=${ENV_DB_PASSWORD}


### PR DESCRIPTION
When the service is being shutdown, `TelegramBot` calls the `stopWebhook` method to stop the webhook, this fires a call to Telegram informing that webhook shouldn't be used anymore.

Under normal circumstances, this isn't a problem. But during Kubernetes rolling update or scale down, the last pod getting killed will inevitably delete the webhook, causing Telegram to stop publishing updates via webhook.