### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -50,6 +50,9 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -52,7 +52,6 @@ jobs:
     needs: build
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/lwschan/weather-bot/security/code-scanning/1](https://github.com/lwschan/weather-bot/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `sonarcloud` job. Since the job primarily involves downloading artifacts and performing a SonarQube scan, it likely only requires `contents: read` and possibly `id-token: write` (if SonarQube uses OpenID Connect for authentication). We will explicitly define these permissions to limit the scope of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
