### PR TITLE
feat: enable structured JSON logging for Loki ingestion

### DIFF
--- a/src/main/resources/application-development.yaml
+++ b/src/main/resources/application-development.yaml
@@ -1,3 +1,8 @@
+logging:
+  structured:
+    format:
+      console: ""
+
 spring:
   config:
     import: optional:file:.env.development[.properties]

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,9 @@ logging:
     org.springframework: INFO
     com.google: INFO
     dev.lewischan.weatherbot: INFO
+  structured:
+    format:
+      console: logstash
 
 management:
   endpoint:


### PR DESCRIPTION
## Summary

Enable structured JSON logging using Spring Boot's built-in structured logging support with the Logstash format, for seamless log ingestion by Grafana Alloy into Loki.

## Changes

- **`application.yaml`** — Added `logging.structured.format.console: logstash` to output all console logs as JSON in the Logstash format
- **`application-development.yaml`** — Disabled structured logging (`console: ""`) to preserve human-readable console output during local development

## Why

Loki works best when ingesting structured (JSON) logs, as it can automatically parse fields like `level`, `logger_name`, `message`, `@timestamp`, `traceId`, and `spanId` — enabling powerful log filtering and correlation in Grafana.

Spring Boot 4.x has built-in structured logging support, so no additional dependencies (e.g. `logstash-logback-encoder`) or custom `logback-spring.xml` are needed.